### PR TITLE
Replace Ollama with GitHub GPT-4.1 for AI chat

### DIFF
--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -4,56 +4,58 @@
   </PropertyGroup>
   <ItemGroup>
     <!-- Aspire Packages -->
-    <PackageVersion Include="Aspire.Hosting.AppHost" Version="13.0.0" />
-    <PackageVersion Include="Aspire.Hosting.Redis" Version="13.0.0" />
-    <PackageVersion Include="Aspire.StackExchange.Redis" Version="13.0.0" />
-    <PackageVersion Include="CommunityToolkit.Aspire.Hosting.Sqlite" Version="9.9.0" />
-    <PackageVersion Include="CommunityToolkit.Aspire.Hosting.Ollama" Version="9.9.0" />
-    <PackageVersion Include="CommunityToolkit.Aspire.OllamaSharp" Version="9.9.0" />
-    <PackageVersion Include="OllamaSharp" Version="5.4.11" />
+    <PackageVersion Include="Aspire.Hosting.AppHost" Version="13.0.2" />
+    <PackageVersion Include="Aspire.Hosting.GitHub.Models" Version="13.0.2" />
+    <PackageVersion Include="Aspire.Hosting.Redis" Version="13.0.2" />
+    <PackageVersion Include="Aspire.OpenAI" Version="13.0.2-preview.1.25603.5" />
+    <PackageVersion Include="Aspire.StackExchange.Redis" Version="13.0.2" />
+    <PackageVersion Include="CommunityToolkit.Aspire.Hosting.Sqlite" Version="13.0.0" />
+    <PackageVersion Include="CommunityToolkit.Aspire.Hosting.Ollama" Version="13.0.0" />
+    <PackageVersion Include="CommunityToolkit.Aspire.OllamaSharp" Version="13.0.1-beta.468" />
+    <PackageVersion Include="OllamaSharp" Version="5.4.12" />
     <!-- ASP.NET Core Packages -->
-    <PackageVersion Include="Microsoft.AspNetCore.Authentication.JwtBearer" Version="10.0.0" />
+    <PackageVersion Include="Microsoft.AspNetCore.Authentication.JwtBearer" Version="10.0.1" />
     <PackageVersion Include="Microsoft.AspNetCore.Identity" Version="2.3.1" />
-    <PackageVersion Include="Microsoft.AspNetCore.Identity.EntityFrameworkCore" Version="10.0.0" />
-    <PackageVersion Include="Microsoft.AspNetCore.Mvc.Testing" Version="10.0.0" />
-    <PackageVersion Include="Microsoft.AspNetCore.OpenApi" Version="10.0.0" />
+    <PackageVersion Include="Microsoft.AspNetCore.Identity.EntityFrameworkCore" Version="10.0.1" />
+    <PackageVersion Include="Microsoft.AspNetCore.Mvc.Testing" Version="10.0.1" />
+    <PackageVersion Include="Microsoft.AspNetCore.OpenApi" Version="10.0.1" />
     <!-- Entity Framework Core Packages -->
-    <PackageVersion Include="Microsoft.EntityFrameworkCore" Version="10.0.0" />
-    <PackageVersion Include="Microsoft.EntityFrameworkCore.Design" Version="10.0.0" />
-    <PackageVersion Include="Microsoft.EntityFrameworkCore.InMemory" Version="10.0.0" />
-    <PackageVersion Include="Microsoft.EntityFrameworkCore.Sqlite" Version="10.0.0" />
+    <PackageVersion Include="Microsoft.EntityFrameworkCore" Version="10.0.1" />
+    <PackageVersion Include="Microsoft.EntityFrameworkCore.Design" Version="10.0.1" />
+    <PackageVersion Include="Microsoft.EntityFrameworkCore.InMemory" Version="10.0.1" />
+    <PackageVersion Include="Microsoft.EntityFrameworkCore.Sqlite" Version="10.0.1" />
     <!-- Microsoft Extensions Packages -->
-    <PackageVersion Include="Microsoft.Extensions.Configuration" Version="10.0.0" />
-    <PackageVersion Include="Microsoft.Extensions.Configuration.Binder" Version="10.0.0" />
-    <PackageVersion Include="Microsoft.Extensions.Configuration.EnvironmentVariables" Version="10.0.0" />
-    <PackageVersion Include="Microsoft.Extensions.Configuration.Json" Version="10.0.0" />
-    <PackageVersion Include="Microsoft.Extensions.Hosting.Abstractions" Version="10.0.0" />
-    <PackageVersion Include="Microsoft.Extensions.Http.Resilience" Version="10.0.0" />
-    <PackageVersion Include="Microsoft.Extensions.Logging.Abstractions" Version="10.0.0" />
-    <PackageVersion Include="Microsoft.Extensions.ServiceDiscovery" Version="10.0.0" />
+    <PackageVersion Include="Microsoft.Extensions.Configuration" Version="10.0.1" />
+    <PackageVersion Include="Microsoft.Extensions.Configuration.Binder" Version="10.0.1" />
+    <PackageVersion Include="Microsoft.Extensions.Configuration.EnvironmentVariables" Version="10.0.1" />
+    <PackageVersion Include="Microsoft.Extensions.Configuration.Json" Version="10.0.1" />
+    <PackageVersion Include="Microsoft.Extensions.Hosting.Abstractions" Version="10.0.1" />
+    <PackageVersion Include="Microsoft.Extensions.Http.Resilience" Version="10.1.0" />
+    <PackageVersion Include="Microsoft.Extensions.Logging.Abstractions" Version="10.0.1" />
+    <PackageVersion Include="Microsoft.Extensions.ServiceDiscovery" Version="10.1.0" />
     <!-- OpenTelemetry Packages -->
     <PackageVersion Include="OpenTelemetry.Exporter.OpenTelemetryProtocol" Version="1.14.0" />
     <PackageVersion Include="OpenTelemetry.Extensions.Hosting" Version="1.14.0" />
-    <PackageVersion Include="OpenTelemetry.Instrumentation.AspNetCore" Version="1.14.0-rc.1" />
-    <PackageVersion Include="OpenTelemetry.Instrumentation.Http" Version="1.14.0-rc.1" />
-    <PackageVersion Include="OpenTelemetry.Instrumentation.Runtime" Version="1.13.0" />
+    <PackageVersion Include="OpenTelemetry.Instrumentation.AspNetCore" Version="1.14.0" />
+    <PackageVersion Include="OpenTelemetry.Instrumentation.Http" Version="1.14.0" />
+    <PackageVersion Include="OpenTelemetry.Instrumentation.Runtime" Version="1.14.0" />
     <!-- Test Packages -->
     <PackageVersion Include="coverlet.collector" Version="6.0.4" />
-    <PackageVersion Include="Microsoft.NET.Test.Sdk" Version="18.0.0" />
+    <PackageVersion Include="Microsoft.NET.Test.Sdk" Version="18.0.1" />
     <PackageVersion Include="Moq" Version="4.20.72" />
     <PackageVersion Include="xunit" Version="2.9.3" />
     <PackageVersion Include="xunit.runner.visualstudio" Version="3.1.5" />
     <!-- MCP Packages -->
-    <PackageVersion Include="ModelContextProtocol" Version="0.4.0-preview.3" />
+    <PackageVersion Include="ModelContextProtocol" Version="0.5.0-preview.1" />
     <PackageVersion Include="ModelContextProtocol.AspNetCore" Version="0.4.0-preview.3" />
     <!-- Microsoft.Extensions.AI -->
-    <PackageVersion Include="Microsoft.Extensions.AI" Version="9.9.0" />
+    <PackageVersion Include="Microsoft.Extensions.AI" Version="10.1.1" />
     <PackageVersion Include="Microsoft.Extensions.AI.Abstractions" Version="9.9.0" />
     <!-- Other Packages -->
     <PackageVersion Include="Microsoft.Extensions.Hosting" Version="10.0.0" />
-    <PackageVersion Include="MudBlazor" Version="8.14.0" />
-    <PackageVersion Include="Scalar.AspNetCore" Version="2.0.0" />
-    <PackageVersion Include="StackExchange.Redis" Version="2.9.32" />
-    <PackageVersion Include="System.IdentityModel.Tokens.Jwt" Version="8.14.0" />
+    <PackageVersion Include="MudBlazor" Version="8.15.0" />
+    <PackageVersion Include="Scalar.AspNetCore" Version="2.11.6" />
+    <PackageVersion Include="StackExchange.Redis" Version="2.10.1" />
+    <PackageVersion Include="System.IdentityModel.Tokens.Jwt" Version="8.15.0" />
   </ItemGroup>
 </Project>

--- a/src/AppHost/AppHost.cs
+++ b/src/AppHost/AppHost.cs
@@ -1,13 +1,12 @@
+using Aspire.Hosting.GitHub;
+
 var builder = DistributedApplication.CreateBuilder(args);
 
 // Add Redis for messaging
 var redis = builder.AddRedis("redis");
 
-// Add Ollama with phi4-mini model for local AI chat (supports MCP tool calling)
-var ollama = builder.AddOllama("ollama")
-    .WithDataVolume()
-    .WithOpenWebUI()
-    .AddModel("phi4-mini");
+// Add GitHub Model (GPT-4.1) for AI chat functionality
+var chat = builder.AddGitHubModel("chat", GitHubModel.OpenAI.OpenAIGpt41);
 
 // Add SQLite databases
 var employeeDb = builder.AddSqlite("employeedb");
@@ -44,6 +43,6 @@ builder.AddProject<Projects.BlazorWeb>("blazorweb")
     .WithReference(authServiceApi)
     .WithReference(notificationServiceApi)
     .WithReference(attendanceServiceApi)
-    .WithReference(ollama);
+    .WithReference(chat);
 
 builder.Build().Run();

--- a/src/AppHost/AppHost.csproj
+++ b/src/AppHost/AppHost.csproj
@@ -12,9 +12,9 @@
 
   <ItemGroup>
     <PackageReference Include="Aspire.Hosting.AppHost" />
+    <PackageReference Include="Aspire.Hosting.GitHub.Models" />
     <PackageReference Include="Aspire.Hosting.Redis" />
     <PackageReference Include="CommunityToolkit.Aspire.Hosting.Sqlite" />
-    <PackageReference Include="CommunityToolkit.Aspire.Hosting.Ollama" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/WebApps/BlazorWeb/BlazorWeb.csproj
+++ b/src/WebApps/BlazorWeb/BlazorWeb.csproj
@@ -6,10 +6,9 @@
   </ItemGroup>
 
   <ItemGroup>
+    <PackageReference Include="Aspire.OpenAI" />
     <PackageReference Include="MudBlazor" />
     <PackageReference Include="ModelContextProtocol" />
-    <PackageReference Include="CommunityToolkit.Aspire.OllamaSharp" />
-    <PackageReference Include="OllamaSharp" />
     <PackageReference Include="Microsoft.Extensions.AI" />
   </ItemGroup>
 

--- a/src/WebApps/BlazorWeb/Program.cs
+++ b/src/WebApps/BlazorWeb/Program.cs
@@ -9,12 +9,11 @@ var builder = WebApplication.CreateBuilder(args);
 // Add service defaults & Aspire client integrations.
 builder.AddServiceDefaults();
 
-// Add Ollama client with Aspire service discovery.
-// AddOllamaApiClient returns a builder, and AddChatClient chains 
+// Add OpenAI client with Aspire service discovery.
+// AddOpenAIClient returns a builder, and AddChatClient chains 
 // the IChatClient registration for use with Microsoft.Extensions.AI.
-// Note: The connection name "ollama-phi4-mini" matches the model resource name from AppHost.cs
-// (created by .AddOllama("ollama").AddModel("phi4-mini"))
-builder.AddOllamaApiClient("ollama-phi4-mini").AddChatClient();
+// Note: The connection name "chat" matches the OpenAI resource name from AppHost.cs
+builder.AddOpenAIClient("chat").AddChatClient();
 
 // Configure MCP options
 builder.Services.Configure<McpOptions>(builder.Configuration.GetSection(McpOptions.SectionName));


### PR DESCRIPTION
Switched from local Ollama (phi4-mini) to cloud-based GitHub Model (GPT-4.1) for AI chat functionality. Updated AppHost to add the new "chat" resource and removed Ollama references. Updated BlazorWeb to use Aspire.OpenAI and register the OpenAI client. Removed OllamaSharp dependencies. Upgraded multiple package versions and added Aspire.Hosting.GitHub.Models and Aspire.OpenAI. All service registrations and references now target the new GPT-4.1 model.